### PR TITLE
Discord Account Hook

### DIFF
--- a/plugins/discord-account-hook
+++ b/plugins/discord-account-hook
@@ -1,0 +1,2 @@
+repository=https://github.com/Cyx-Development/DAH.git
+commit=f0919b02c0e4a492a3619d28d56ca726bf0eb816


### PR DESCRIPTION
Sends Discord Notification with Client Authorization Key. 
For Users who can not claim Webhook URL or Bot Token.